### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,20 +1,20 @@
-#ATTRIBUTION
+# ATTRIBUTION
 
 The quattroshapes are released by foursquare under [CC-BY](http://creativecommons.org/licenses/by/2.0/) attribution license.
 
 Please include attribution in your app, site, or printed work. Sample wording: "Includes data from foursquare quattroshapes" with a link to this Github repo.
 
-#ADDITIONAL ATTRIBUTION
+# ADDITIONAL ATTRIBUTION
 
 This map database contains open data from government and other sources. Consider including the following copyright statements when using the data. 
 
-###Global gazetters and data
+### Global gazetters and data
 
 * Geonames.org
 * Yahoo! GeoPlanet
 * Flickr geotagged photos
 
-###Europe
+### Europe
 
 EuroGeoGraphics data copyright is held by European National Mapping Agencies. 
 
@@ -58,7 +58,7 @@ EuroGeoGraphics data copyright is held by European National Mapping Agencies.
 * Switzerland © Bundesamt für Landestopographie
 * Ukraine © Research Institute of Geodesy and Cartography
 
-###Additional European data
+### Additional European data
 
 * United Kingdom: Contains Ordnance Survey data © Crown copyright and database right [2012]
 * Netherlands: Kadaster
@@ -67,7 +67,7 @@ EuroGeoGraphics data copyright is held by European National Mapping Agencies.
 * Switzerland: swisstopo
 * Europe-wide: European Environment Agency (EEA) [urban morphological zones 2006](http://www.eea.europa.eu/data-and-maps/data/urban-morphological-zones-2006-umz2006-f3v0)
 
-###Americas
+### Americas
 
 * United States: US Census Bureau (Census 2010 geography files). 
 * Canada: © Department of Natural Resources Canada. All rights reserved., Statistics Canada, and BC Stats
@@ -75,7 +75,7 @@ EuroGeoGraphics data copyright is held by European National Mapping Agencies.
 * Mexico: INEGI
 * Chile: Global Map of Chile © International Steering Committee for Global Mapping / Instituto Geografico Militar de Chile
 
-###Asia
+### Asia
 
 * Indonesia: Global Map of Indonesia @ ISCGM/Indonesia
 * Australian: Geoscience Australia and Australian Bureau of Statistics

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#quattroshapes
+# quattroshapes
 
 _The Global Polygon Gazetteer_
 
@@ -22,7 +22,7 @@ Enjoy!
 
 ---
 
-##Downloads
+## Downloads
 
 Shapefiles are in WGS84 (geographic) projection and UTF-8 character encoding. 
 
@@ -35,7 +35,7 @@ Shapefiles are in WGS84 (geographic) projection and UTF-8 character encoding.
 * [quatroshapes localities](http://static.quattroshapes.com/qs_localities.zip) - 420 mb
 * [quatroshapes neighborhoods](http://static.quattroshapes.com/qs_neighborhoods.zip) - 32 mb
 
-##Goodies
+## Goodies
 
 quatroshapes gazetteer (gzipped geojson):
 
@@ -53,7 +53,7 @@ Other:
 * [GeoPlanet voronoi diagrams](http://static.quattroshapes.com/geoplanet_voronoi.zip) - 198 mb includes adm0, adm1, adm2, localadmin & localities.
 
  
-##Preview
+## Preview
 
 **Administrative level 1**: 
 _(below) States and provinces in orange; regions shown in red. Mix of national mapping agency and Natural Earth._


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
